### PR TITLE
Ignore base style

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,5 +8,6 @@
   ],
   "less": {
     "relativeUrls": true
-  }
+  },
+  "ignore": ["styles/base.less"]
 }


### PR DESCRIPTION
This is needed because when LESS tries to build base.less by itself the @color variable is not set and thus you get an error
